### PR TITLE
AR-191 remove eval

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'rubygems/package_task'
 require 'rake/testtask'
 
-spec = eval(File.new("wkhtmltopdf-binary.gemspec").readlines.join("\n"))
+spec = Gem::Specification.load('wkhtmltopdf-binary.gemspec')
 
 Gem::PackageTask.new(spec) do |pkg|
   pkg.need_tar = true


### PR DESCRIPTION
AR-191_remove_eval avoided the use of eval by using Gem::Specification.load