### PR TITLE
DCV-3085 fix

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -11,6 +11,7 @@ require 'rbconfig'
 require 'fileutils'
 require 'logger'
 require 'digest'
+require 'shellwords'
 
 LOGGER = Logger.new $stderr
 


### PR DESCRIPTION
After Ruby and Rails have been updated, there was an issue with Shellwords class not being found. Gem 'shellwords' is distributed with Ruby and with Ruby update it was updated from 0.1 to 0.2. Looking at changes, there are no breaking or any functional changes between the two.  I'm not sure how this became and issue. Most likely there was change on config or behavior for gem loading/pre-loading, but I didn't investigate further. Adding require statement fixes the issue.