### PR TITLE
GSL-1173 #comment add env variable to remove tmp files

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -89,7 +89,7 @@ begin
 
   pdf_succeeded = true
 ensure
-  keep_on_failure = ENV.fetch('WKHTMLTOPDF_KEEP_TMP_FILES_ON_FAILURE', 'true').casecmp('true').zero?
+  keep_on_failure = ENV.fetch('WKHTMLTOPDF_KEEP_TMP_FILES_ON_FAILURE', 'false').casecmp('true').zero?
   if pdf_succeeded || !keep_on_failure
     FileUtils.rm_f html_path
     FileUtils.rm_f output_path

--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -64,27 +64,34 @@ chromium_command =
   'chromium --headless --disable-gpu --dump-dom ' \
   "#{Shellwords.escape(html_url)} > #{Shellwords.escape(output_path)}"
 
-LOGGER.info "Executing command: #{chromium_command}"
-success = log_duration('PDF: chromium execution') do
-  system chromium_command
+pdf_succeeded = false
+begin
+  LOGGER.info "Executing command: #{chromium_command}"
+  success = log_duration('PDF: chromium execution') do
+    system chromium_command
+  end
+  raise "chromium failed to generate HTML with '#{uuid}' UUID." unless success
+
+  # append parameters to the original URL. output=true tells Rails to return
+  # file with output_prefix (preprocessed by Chromium). Digest confirms that we
+  # have access to the file
+  ARGV[-2] += "?output=true&digest=#{Digest::SHA256.file(output_path).hexdigest}"
+
+  cmd = ARGV.unshift(binary)
+  cmd.insert(-3, '--enable-local-file-access')
+
+  LOGGER.info "Executing command: #{cmd}"
+  success = log_duration('PDF: wkhtmltopdf execution') do
+    system(*cmd)
+  end
+
+  raise "wkhtmltopdf failed to generate HTML with '#{uuid}' UUID." unless success
+
+  pdf_succeeded = true
+ensure
+  keep_on_failure = ENV.fetch('WKHTMLTOPDF_KEEP_TMP_FILES_ON_FAILURE', 'true').casecmp('true').zero?
+  if pdf_succeeded || !keep_on_failure
+    FileUtils.rm_f html_path
+    FileUtils.rm_f output_path
+  end
 end
-raise "chromium failed to generate HTML with '#{uuid}' UUID." unless success
-
-# append parameters to the original URL. output=true tells Rails to return
-# file with output_prefix (preprocessed by Chromium). Digest confirms that we
-# have access to the file
-ARGV[-2] += "?output=true&digest=#{Digest::SHA256.file(output_path).hexdigest}"
-
-cmd = ARGV.unshift(binary)
-cmd.insert(-3, '--enable-local-file-access')
-
-LOGGER.info "Executing command: #{cmd}"
-success = log_duration('PDF: wkhtmltopdf execution') do
-  system(*cmd)
-end
-
-raise "wkhtmltopdf failed to generate HTML with '#{uuid}' UUID." unless success
-
-# clean up temporary files
-FileUtils.rm_f html_path
-FileUtils.rm_f output_path

--- a/wkhtmltopdf-binary.gemspec
+++ b/wkhtmltopdf-binary.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "wkhtmltopdf-binary"
-  s.version = "0.12.6.1"
+  s.version = "0.12.6.2"
   s.license = "Apache-2.0"
   s.author = "Zakir Durumeric"
   s.email = "zakird@gmail.com"


### PR DESCRIPTION
[GSL-1173]

Add support for new env variable WKHTMLTOPDF_KEEP_TMP_FILES_ON_FAILURE. which deletes the temp files on failure based on value set. 

Note:  ENV is set in Kings-landing.  since we running as bash command. env will be propagated to gem directly





[GSL-1173]: https://glooko.atlassian.net/browse/GSL-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ